### PR TITLE
Bump versions to recent ones

### DIFF
--- a/ancient/Dockerfile
+++ b/ancient/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.opensource.zalan.do/stups/ubuntu:UPSTREAM
 MAINTAINER Zalando SE
 
-# snippet from https://github.com/nodejs/docker-node/blob/6778e14c0c1ae53cc413f77a94c21c7cf05f651f/0.12/wheezy/Dockerfile
+# snippet from https://github.com/nodejs/docker-node/blob/50b56d39a236fd519eda2231757aa2173e270807/0.12/wheezy/Dockerfile
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -20,8 +20,8 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.12.14
-ENV NPM_VERSION 3.8.9
+ENV NODE_VERSION 0.12.15
+ENV NPM_VERSION 3.10.6
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.opensource.zalan.do/stups/ubuntu:UPSTREAM
 MAINTAINER Zalando SE
 
-# snippet from https://github.com/nodejs/docker-node/blob/fdcbbd6445c70290c50396cba2b2b67357a00629/4.4/wheezy/Dockerfile
+# snippet from https://github.com/nodejs/docker-node/blob/4ad33b57b2fa9d9bfc92e2369b14adb42e1eb90c/4.5/wheezy/Dockerfile
 
 RUN set -ex \
   && for key in \
@@ -20,8 +20,8 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.4.5
-ENV NPM_VERSION 3.9.5
+ENV NODE_VERSION 4.5.0
+ENV NPM_VERSION 3.10.6
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -3,7 +3,7 @@
 FROM registry.opensource.zalan.do/stups/ubuntu:UPSTREAM
 MAINTAINER Zalando SE
 
-# snippet from https://github.com/nodejs/docker-node/blob/466e418a117f33c1cd550414ae1b39423319a265/6.2/wheezy/Dockerfile
+# snippet from https://github.com/nodejs/docker-node/blob/be9abca6b1be7657fd0f00f005b867393184d19c/6.4/wheezy/Dockerfile
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -21,8 +21,8 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.2.1
-ENV NPM_VERSION 3.9.5
+ENV NODE_VERSION 6.4.0
+ENV NPM_VERSION 3.10.6
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
I did not bump the version for appDynamics because by using version 4.2.4 of the appDynamics agent all node versions are supported. See the following post: 

https://docs.appdynamics.com/display/PRO42/Node.js+Supported+Environments

> As of 4.2.4, the Node.js Agent supports all major and minor versions of Node.js v0, v4, v5, and v6. Further, the agent no longer needs to be updated for each new minor version update of Node.js.
