### PR TITLE
Upgrade version: npm@5

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex \
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 7.10.0
-ENV NPM_VERSION 5.0.1
+ENV NPM_VERSION 5.0.3
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex \
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 7.10.0
-ENV NPM_VERSION 4.5.0
+ENV NPM_VERSION 5.0.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -34,6 +34,6 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc SHASUMS256.txt \
   && npm install -g npm@"$NPM_VERSION" \
-  && npm cache clear
+  && npm cache clean --force
 
 CMD [ "node" ]

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex \
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 7.10.0
-ENV NPM_VERSION 5.0.3
+ENV NPM_VERSION 5.1.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
Upgrading npm of `stable`. Leaving `lts` as is because [Node.js LTS doc](https://github.com/nodejs/LTS#lts-plan) says LTS is limited to "Non-semver-major npm updates".

Also, changing `npm cache clear` (alias of `npm cache clean`) to `npm cache clean --force` because now the command requires `--force`. https://docs.npmjs.com/cli/cache#details

Fixes #33