### PR TITLE
Bump lts version to 6.11.2

### DIFF
--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -1,24 +1,23 @@
 FROM registry.opensource.zalan.do/stups/ubuntu:latest
 MAINTAINER Zalando SE
 
-# snippet from https://github.com/nodejs/docker-node/blob/0cc4ebee1bdaf90402e68d1a3d469e8f3712337d/6.9/wheezy/Dockerfile
+# snippet from https://github.com/nodejs/docker-node/blob/d77913eb25c2b98a241344d79c6397e431c298a8/6.11/wheezy/Dockerfile
 
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \
   && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
     94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
     FD3A5288F042B6850C66B31F09FE44734EB7990E \
     71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
     DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
     56730D5401028683275BD23C23EFEFE93C4CFFFE \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    93C7E9E91B49E432C2F75674B0A78B0A6C481CF6 \
-    114F43EE0176B71C7BC219DD50A3051F888C628D \
-    7937DFD2AB06298B2293C3187D33FF9D0246406D \
   ; do \
-    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key"; \
+    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info

--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.11.0
+ENV NODE_VERSION 6.11.2
 ENV NPM_VERSION 4.6.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz"


### PR DESCRIPTION
This PR not only bumps LTS to `6.11.2` it also updates the gpg key part according to the official docker node Dockerfile:

https://github.com/nodejs/docker-node/blob/d77913eb25c2b98a241344d79c6397e431c298a8/6.11/wheezy/Dockerfile