### PR TITLE
Bump versions

### DIFF
--- a/current/Dockerfile
+++ b/current/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 10.14.1
+ENV NODE_VERSION 10.14.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/current/Dockerfile
+++ b/current/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 10.12.0
+ENV NODE_VERSION 10.14.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/current/Dockerfile
+++ b/current/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.opensource.zalan.do/stups/ubuntu:latest
-MAINTAINER Zalando SE
+LABEL maintainer "Zalando SE"
 
 RUN set -ex; \
        apt-get update; \

--- a/current/Dockerfile.alpine
+++ b/current/Dockerfile.alpine
@@ -1,5 +1,5 @@
 FROM registry.opensource.zalan.do/stups/alpine:latest
-MAINTAINER Zalando SE
+LABEL maintainer "Zalando SE"
 
 # snippet from: https://github.com/nodejs/docker-node/blob/72dd945d29dee5afa73956ebc971bf3a472442f7/10/alpine/Dockerfile
 

--- a/current/Dockerfile.alpine
+++ b/current/Dockerfile.alpine
@@ -3,7 +3,7 @@ MAINTAINER Zalando SE
 
 # snippet from: https://github.com/nodejs/docker-node/blob/72dd945d29dee5afa73956ebc971bf3a472442f7/10/alpine/Dockerfile
 
-ENV NODE_VERSION 10.12.0
+ENV NODE_VERSION 10.14.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/current/Dockerfile.alpine
+++ b/current/Dockerfile.alpine
@@ -3,7 +3,7 @@ LABEL maintainer "Zalando SE"
 
 # snippet from: https://github.com/nodejs/docker-node/blob/72dd945d29dee5afa73956ebc971bf3a472442f7/10/alpine/Dockerfile
 
-ENV NODE_VERSION 10.14.1
+ENV NODE_VERSION 10.14.2
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.opensource.zalan.do/stups/ubuntu:latest
-MAINTAINER Zalando SE
+LABEL maintainer "Zalando SE"
 
 RUN set -ex; \
        apt-get update; \

--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -33,7 +33,7 @@ RUN set -ex \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 8.12.0
+ENV NODE_VERSION 8.14.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/lts/Dockerfile.alpine
+++ b/lts/Dockerfile.alpine
@@ -3,7 +3,7 @@ MAINTAINER Zalando SE
 
 # snippet from: https://github.com/nodejs/docker-node/blob/72dd945d29dee5afa73956ebc971bf3a472442f7/8/alpine/Dockerfile
 
-ENV NODE_VERSION 8.12.0
+ENV NODE_VERSION 8.14.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/lts/Dockerfile.alpine
+++ b/lts/Dockerfile.alpine
@@ -1,5 +1,5 @@
 FROM registry.opensource.zalan.do/stups/alpine:latest
-MAINTAINER Zalando SE
+LABEL maintainer "Zalando SE"
 
 # snippet from: https://github.com/nodejs/docker-node/blob/72dd945d29dee5afa73956ebc971bf3a472442f7/8/alpine/Dockerfile
 


### PR DESCRIPTION
There were security release for both branches, so it would be good to get the latest versions available.

I also switched to the non deprecated version of defining the maintainer.