### PR TITLE
Update node versions

### DIFF
--- a/current/Dockerfile
+++ b/current/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 12.10.0
+ENV NODE_VERSION 13.12.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/current/Dockerfile.alpine
+++ b/current/Dockerfile.alpine
@@ -3,7 +3,7 @@ LABEL maintainer "Zalando SE"
 
 # snippet from: https://github.com/nodejs/docker-node/blob/72dd945d29dee5afa73956ebc971bf3a472442f7/10/alpine/Dockerfile
 
-ENV NODE_VERSION 12.10.0
+ENV NODE_VERSION 13.12.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/lts/Dockerfile
+++ b/lts/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 10.16.3
+ENV NODE_VERSION 12.16.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/lts/Dockerfile.alpine
+++ b/lts/Dockerfile.alpine
@@ -3,7 +3,7 @@ LABEL maintainer "Zalando SE"
 
 # snippet from: https://github.com/nodejs/docker-node/blob/72dd945d29dee5afa73956ebc971bf3a472442f7/8/alpine/Dockerfile
 
-ENV NODE_VERSION 10.16.3
+ENV NODE_VERSION 12.16.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \


### PR DESCRIPTION
- current -> 13.12.0
- lts -> 12.16.1

Upgrade node because of critical security issue:
https://snyk.io/blog/node-js-release-fixes-a-critical-http-security-vulnerability/

> `FEBRUARY 6, 2020` All actively supported versions 10.x, 12.x, and 13.x of Node.js are vulnerable. We strongly encourage you to upgrade as soon as you can to the following fixed versions: 10.19.0, 12.15.0 and 13.8.0